### PR TITLE
fix: Ensure tags always have successful releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -36,6 +36,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   auto-tag:
@@ -49,6 +50,38 @@ jobs:
         with:
           fetch-depth: 0  # Required: fetch full history for tag analysis
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check and clean incomplete releases
+        id: check_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tags = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 10
+            });
+
+            for (const tag of tags.data) {
+              try {
+                await github.rest.repos.getReleaseByTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag: tag.name
+                });
+                console.log(`Release exists for tag ${tag.name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  console.log(`No release found for tag ${tag.name}, deleting tag`);
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `tags/${tag.name}`
+                  });
+                  console.log(`Deleted tag ${tag.name}`);
+                }
+              }
+            }
 
       - name: Bump version and push tag
         id: tag_version
@@ -71,6 +104,20 @@ jobs:
             ci:patch:CI/CD,
             revert:patch:Reverts
 
+      - name: Trigger Release Workflow
+        if: steps.tag_version.outputs.new_tag != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'release-tag-created',
+              client_payload: {
+                tag: '${{ steps.tag_version.outputs.new_tag }}'
+              }
+            });
+
       - name: Summary
         if: steps.tag_version.outputs.new_tag != ''
         run: |
@@ -85,7 +132,7 @@ jobs:
           echo "${{ steps.tag_version.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🚀 Release workflow will trigger automatically on tag push" >> $GITHUB_STEP_SUMMARY
+          echo "🚀 Release workflow triggered via repository_dispatch" >> $GITHUB_STEP_SUMMARY
 
       - name: No tag created
         if: steps.tag_version.outputs.new_tag == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ on:
   push:
     tags:
       - 'v*'
+  repository_dispatch:
+    types: [release-tag-created]
   workflow_dispatch:
     inputs:
       tag:
@@ -63,6 +65,8 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.tag }}" ]; then
             TAG="${{ github.event.inputs.tag }}"
+          elif [ -n "${{ github.event.client_payload.tag }}" ]; then
+            TAG="${{ github.event.client_payload.tag }}"
           else
             TAG="${{ github.ref_name }}"
           fi
@@ -98,6 +102,7 @@ jobs:
           fi
 
       - name: Publish to Maven Central
+        id: maven_publish
         if: steps.version.outputs.is_snapshot == 'false'
         run: sbt --batch --no-colors ci-release
         env:
@@ -108,6 +113,7 @@ jobs:
           GITHUB_REF: refs/tags/${{ steps.tag.outputs.tag }}  # Tell sbt-ci-release this is a tag build
 
       - name: Publish SNAPSHOT to Sonatype
+        id: snapshot_publish
         if: steps.version.outputs.is_snapshot == 'true'
         run: sbt --batch --no-colors +publishSigned
         env:
@@ -117,6 +123,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
       - name: Package CLI artifacts
+        id: package_cli
         run: sbt --batch --no-colors cli/Universal/packageBin cli/Universal/packageZipTarball
 
       - name: Create GitHub Release


### PR DESCRIPTION
Auto-tag checks for incomplete releases and deletes orphaned tags. 
Tags are recreated on next push until release succeeds. 
Release workflow triggers via `repository_dispatch`.