### PR TITLE
fix: Force sbt-ci-release to do full release via CI_RELEASE env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,8 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          GITHUB_REF: refs/tags/${{ steps.tag.outputs.tag }}  # Tell sbt-ci-release this is a tag build
+          CI_RELEASE: publishSigned
+          GITHUB_REF: refs/tags/${{ steps.tag.outputs.tag }}
 
       - name: Publish SNAPSHOT to Sonatype
         id: snapshot_publish


### PR DESCRIPTION
Prevents snapshot detection error when triggered via repository_dispatch.