### PR TITLE
fix: ci-release step exports both CI_COMMIT_TAG and BUILD_SOURCEBRANC…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,8 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           CI_RELEASE: publishSigned
+          CI_COMMIT_TAG: ${{ steps.tag.outputs.tag }}
+          BUILD_SOURCEBRANCH: refs/tags/${{ steps.tag.outputs.tag }}
           GITHUB_REF: refs/tags/${{ steps.tag.outputs.tag }}
 
       - name: Publish SNAPSHOT to Sonatype


### PR DESCRIPTION
…H (alongside GITHUB_REF) with the actual tag being released.