### PR TITLE
fix: align encode layout with latest fixtures

### DIFF
--- a/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
@@ -438,7 +438,7 @@ object Encoders {
             options.delimiter,
           )
           writer.pushListItem(depth, header)
-          arr.foreach(elem => encodeListItem(elem, writer, depth + 1, options, headAllow))
+          arr.foreach(elem => encodeListItem(elem, writer, depth + 2, options, headAllow))
         }
       case JArray(arr) =>
         val header = formatHeader(
@@ -448,7 +448,7 @@ object Encoders {
           options.delimiter,
         )
         writer.pushListItem(depth, header)
-        arr.foreach(elem => encodeListItem(elem, writer, depth + 1, options, headAllow))
+        arr.foreach(elem => encodeListItem(elem, writer, depth + 2, options, headAllow))
       case JObj(next) =>
         writer.pushListItem(depth, s"${encodeKey(firstKey)}:")
         encodeObject(next, writer, depth + 2, options, headAllow)

--- a/core/src/main/scala/io/toonformat/toon4s/encode/Writer.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Writer.scala
@@ -199,8 +199,11 @@ final class LineWriter(indentSize: Int) extends EncodeLineWriter {
   def pushListItem(depth: Int, line: String): Unit = {
     if (!first) builder.append('\n') else first = false
     pad(depth)
-    builder.append("- ")
-    builder.append(line)
+    if (line.isEmpty) builder.append('-')
+    else {
+      builder.append("- ")
+      builder.append(line)
+    }
   }
 
   /**
@@ -267,8 +270,11 @@ final class StreamLineWriter(indentSize: Int, out: Writer) extends StreamingEnco
   def pushListItem(depth: Int, line: String): Unit = {
     if (!first) out.write('\n') else first = false
     pad(depth)
-    out.write("- ")
-    out.write(line)
+    if (line.isEmpty) out.write('-')
+    else {
+      out.write("- ")
+      out.write(line)
+    }
   }
 
   // ========================================================================


### PR DESCRIPTION
Match v3 row depth and emit bare '-' for empty object list items.