### PR TITLE
spark P0 compatibility fixes

### DIFF
--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/integrations/IcebergTimeTravelTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/integrations/IcebergTimeTravelTest.scala
@@ -1,0 +1,16 @@
+package io.toonformat.toon4s.spark.integrations
+
+import java.time.Instant
+
+import munit.FunSuite
+
+class IcebergTimeTravelTest extends FunSuite {
+
+  test("asOfTimestampOptionValue uses epoch millis") {
+    val instant = Instant.parse("2024-12-01T00:00:00Z")
+    val optionValue = IcebergTimeTravel.asOfTimestampOptionValue(instant)
+
+    assertEquals(optionValue, "1733011200000")
+  }
+
+}


### PR DESCRIPTION
This PR applies the P0 Spark fixes.

- use a Spark Connect safe DataFrame creation path
- fix Iceberg as-of-timestamp option value
- align Delta CDC error handling text and behavior
- add a test for Iceberg timestamp option value