### PR TITLE
docs grow spark maintainer coverage for issue 67

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ Thanks for your interest in contributing to toon4s.
 - Include Spark version, Scala version, and a minimal repro.
 - Maintainers triage new issues and follow up through issue threads.
 - Look for `good first issue` and `help wanted` labels if you want a small starter task.
+- Current starter tasks:
+  - `#71` spark add benchmark result parser script
+  - `#72` spark add usage docs for writeToLlmPartitions idempotency key
+  - `#73` spark add sample DataSource V2 write failure test
 
 ## Helpful guide
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,8 @@ This project is maintained under `com-vitthalmirji`.
 
 ## Backup and continuity
 
+- Spark integration backup reviewer: [@rorygraves](https://github.com/rorygraves) for non-blocking review coverage.
 - If the primary maintainer is unavailable for more than 14 days, active contributors may request maintainer access through a GitHub issue.
 - Small, scoped pull requests with tests are preferred so review can be shared across contributors.
 - Use `good first issue` and `help wanted` labels to grow maintainer coverage.
+- Track first external issue-to-merge flow in `#74`.


### PR DESCRIPTION
## Summary
- add explicit spark backup reviewer note in maintainers doc
- add three good first issues in contributing doc
- add tracking reference for first external issue-to-merge flow

## Tracker issues created
- #71
- #72
- #73
- #74

Closes #67
