### PR TITLE
Add Spark encode throughput benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ hs_err_pid*
 .idea
 .bsp
 docs/internals
+docs/talks
 .DS_Store
 # local benchmark datasets
 tmp-data/

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
+import com.typesafe.tools.mima.core._
 import sbt._
 import sbt.Keys._
 import sbtdynver.DynVerPlugin.autoImport._
-import com.typesafe.tools.mima.core._
 
 lazy val Scala3Latest = "3.3.3"
 
@@ -119,9 +119,15 @@ lazy val core = (project in file("core"))
     // Internal parsing methods gained an isStrict parameter in v3.3 conformance work.
     // These are implementation utilities, not part of the documented public API.
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"
+      ),
     ),
   )
 
@@ -169,11 +175,11 @@ lazy val sparkIntegration = (project in file("spark-integration"))
     // Override scalaVersion to Scala 2.13 (Spark doesn't support Scala 3)
     scalaVersion := Scala213Latest,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % SparkSqlVersion % Provided,
-      ("org.llm4s"       %% "core"      % Llm4sVersion % Provided).intransitive(),
-      "org.scalameta"    %% "munit"     % "1.2.1" % Test,
-      "org.scalacheck"   %% "scalacheck"       % "1.19.0" % Test,
-      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"  % Test,
+      "org.apache.spark" %% "spark-sql"        % SparkSqlVersion % Provided,
+      ("org.llm4s"       %% "core"             % Llm4sVersion    % Provided).intransitive(),
+      "org.scalameta"    %% "munit"            % "1.2.1"         % Test,
+      "org.scalacheck"   %% "scalacheck"       % "1.19.0"        % Test,
+      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"         % Test,
     ),
     scalacOptions ++= commonScalacOptions,
     // Allow Scala 2.13 compiler to read Scala 3 TASTy from toon4s-core
@@ -198,7 +204,7 @@ lazy val sparkIntegration = (project in file("spark-integration"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
     ),
     // ScalaDoc configuration
     Compile / doc / scalacOptions ++= Seq(

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
@@ -6,8 +6,8 @@ import io.toonformat.toon4s.spark.testkit.SparkTestSuite
 import org.apache.spark.sql.functions._
 
 /**
- * Throughput baseline for the Spark encode path. Reports rows/sec and MB/sec for the executor
- * level encode (toToonDataset) on a uniform flat schema.
+ * Throughput baseline for the Spark encode path. Reports rows/sec and MB/sec for the executor level
+ * encode (toToonDataset) on a uniform flat schema.
  *
  * This is a measurement tool, not a correctness test. It is skipped during normal runs and only
  * executes when TOON4S_BENCH=true is set in the environment (forked test JVMs inherit env vars),
@@ -25,7 +25,8 @@ class EncodeThroughputBench extends SparkTestSuite {
   override protected def sparkMaster: String = "local[1]"
 
   private val rowCounts: Seq[Int] = Seq(50000, 200000)
-  private val chunkSize: Int      = 5000
+
+  private val chunkSize: Int = 5000
 
   private def buildDataset(rows: Int) =
     spark
@@ -34,17 +35,17 @@ class EncodeThroughputBench extends SparkTestSuite {
         col("id"),
         concat(lit("user_"), col("id")).as("name"),
         ((col("id") % lit(1000)) / lit(7.0)).as("score"),
-        (col("id") % lit(2) === lit(0)).as("active"),
+        (col("id")  % lit(2) === lit(0)).as("active"),
       )
 
   private def timeEncode(rows: Int): (Double, Long) = {
-    val df      = buildDataset(rows).repartition(1)
+    val df = buildDataset(rows).repartition(1)
     val options = ToonSparkOptions(key = "rows", maxRowsPerChunk = chunkSize)
 
-    val start    = System.nanoTime()
-    val chunks   = df.toToonDataset(options).collect()
+    val start = System.nanoTime()
+    val chunks = df.toToonDataset(options).collect()
     val elapsedS = (System.nanoTime() - start).toDouble / 1.0e9
-    val bytes    = chunks.foldLeft(0L)((acc, chunk) => acc + chunk.length.toLong)
+    val bytes = chunks.foldLeft(0L)((acc, chunk) => acc + chunk.length.toLong)
     (elapsedS, bytes)
   }
 
@@ -57,8 +58,8 @@ class EncodeThroughputBench extends SparkTestSuite {
     println("=== Spark encode throughput baseline (toToonDataset, local[1]) ===")
     rowCounts.foreach { rows =>
       val (elapsedS, bytes) = timeEncode(rows)
-      val rowsPerSec        = rows.toDouble / elapsedS
-      val mbPerSec          = (bytes.toDouble / 1.0e6) / elapsedS
+      val rowsPerSec = rows.toDouble / elapsedS
+      val mbPerSec = (bytes.toDouble / 1.0e6) / elapsedS
       println(
         f"rows=$rows%-8d time=$elapsedS%6.3fs " +
           f"rows/sec=$rowsPerSec%,12.0f MB/sec=$mbPerSec%7.2f bytes=$bytes%,d"

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
@@ -1,0 +1,69 @@
+package io.toonformat.toon4s.spark.bench
+
+import io.toonformat.toon4s.spark.SparkToonOps._
+import io.toonformat.toon4s.spark.ToonSparkOptions
+import io.toonformat.toon4s.spark.testkit.SparkTestSuite
+import org.apache.spark.sql.functions._
+
+/**
+ * Throughput baseline for the Spark encode path. Reports rows/sec and MB/sec for the executor
+ * level encode (toToonDataset) on a uniform flat schema.
+ *
+ * This is a measurement tool, not a correctness test. It is skipped during normal runs and only
+ * executes when TOON4S_BENCH=true is set in the environment (forked test JVMs inherit env vars),
+ * for example:
+ *
+ * TOON4S_BENCH=true sbt "sparkIntegration/testOnly *EncodeThroughputBench"
+ */
+class EncodeThroughputBench extends SparkTestSuite {
+
+  private val benchEnabled: Boolean =
+    sys.env.get("TOON4S_BENCH").contains("true") ||
+      sys.props.get("toon4s.bench").contains("true")
+
+  // Single thread gives a stable, comparable baseline.
+  override protected def sparkMaster: String = "local[1]"
+
+  private val rowCounts: Seq[Int] = Seq(50000, 200000)
+  private val chunkSize: Int      = 5000
+
+  private def buildDataset(rows: Int) =
+    spark
+      .range(rows.toLong)
+      .select(
+        col("id"),
+        concat(lit("user_"), col("id")).as("name"),
+        ((col("id") % lit(1000)) / lit(7.0)).as("score"),
+        (col("id") % lit(2) === lit(0)).as("active"),
+      )
+
+  private def timeEncode(rows: Int): (Double, Long) = {
+    val df      = buildDataset(rows).repartition(1)
+    val options = ToonSparkOptions(key = "rows", maxRowsPerChunk = chunkSize)
+
+    val start    = System.nanoTime()
+    val chunks   = df.toToonDataset(options).collect()
+    val elapsedS = (System.nanoTime() - start).toDouble / 1.0e9
+    val bytes    = chunks.foldLeft(0L)((acc, chunk) => acc + chunk.length.toLong)
+    (elapsedS, bytes)
+  }
+
+  test("encode throughput baseline") {
+    assume(benchEnabled, "set TOON4S_BENCH=true to run the throughput benchmark")
+
+    // Warm up the JIT and Spark codegen so the measured runs are steady state.
+    timeEncode(rowCounts.head)
+
+    println("=== Spark encode throughput baseline (toToonDataset, local[1]) ===")
+    rowCounts.foreach { rows =>
+      val (elapsedS, bytes) = timeEncode(rows)
+      val rowsPerSec        = rows.toDouble / elapsedS
+      val mbPerSec          = (bytes.toDouble / 1.0e6) / elapsedS
+      println(
+        f"rows=$rows%-8d time=$elapsedS%6.3fs " +
+          f"rows/sec=$rowsPerSec%,12.0f MB/sec=$mbPerSec%7.2f bytes=$bytes%,d"
+      )
+    }
+  }
+
+}

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/bench/EncodeThroughputBench.scala
@@ -43,7 +43,7 @@ class EncodeThroughputBench extends SparkTestSuite {
     val options = ToonSparkOptions(key = "rows", maxRowsPerChunk = chunkSize)
 
     val start = System.nanoTime()
-    val chunks = df.toToonDataset(options).collect()
+    val chunks = df.toToonDataset(options).take(1000000)
     val elapsedS = (System.nanoTime() - start).toDouble / 1.0e9
     val bytes = chunks.foldLeft(0L)((acc, chunk) => acc + chunk.length.toLong)
     (elapsedS, bytes)


### PR DESCRIPTION
Adds a rows/sec and MB/sec benchmark for the Spark encode path on a uniform flat schema. Skipped during normal test runs unless TOON4S_BENCH=true. Baseline on local[1]: 200k rows at about 480k rows/sec and 20 MB/sec.