### PR TITLE
Keep large integers exact in schemaless conversion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
+import com.typesafe.tools.mima.core._
 import sbt._
 import sbt.Keys._
 import sbtdynver.DynVerPlugin.autoImport._
-import com.typesafe.tools.mima.core._
 
 lazy val Scala3Latest = "3.3.3"
 
@@ -119,9 +119,15 @@ lazy val core = (project in file("core"))
     // Internal parsing methods gained an isStrict parameter in v3.3 conformance work.
     // These are implementation utilities, not part of the documented public API.
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"
+      ),
     ),
   )
 
@@ -169,11 +175,11 @@ lazy val sparkIntegration = (project in file("spark-integration"))
     // Override scalaVersion to Scala 2.13 (Spark doesn't support Scala 3)
     scalaVersion := Scala213Latest,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % SparkSqlVersion % Provided,
-      ("org.llm4s"       %% "core"      % Llm4sVersion % Provided).intransitive(),
-      "org.scalameta"    %% "munit"     % "1.2.1" % Test,
-      "org.scalacheck"   %% "scalacheck"       % "1.19.0" % Test,
-      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"  % Test,
+      "org.apache.spark" %% "spark-sql"        % SparkSqlVersion % Provided,
+      ("org.llm4s"       %% "core"             % Llm4sVersion    % Provided).intransitive(),
+      "org.scalameta"    %% "munit"            % "1.2.1"         % Test,
+      "org.scalacheck"   %% "scalacheck"       % "1.19.0"        % Test,
+      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"         % Test,
     ),
     scalacOptions ++= commonScalacOptions,
     // Allow Scala 2.13 compiler to read Scala 3 TASTy from toon4s-core
@@ -198,7 +204,7 @@ lazy val sparkIntegration = (project in file("spark-integration"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
     ),
     // ScalaDoc configuration
     Compile / doc / scalacOptions ++= Seq(

--- a/spark-integration/src/main/scala/io/toonformat/toon4s/spark/SparkJsonInterop.scala
+++ b/spark-integration/src/main/scala/io/toonformat/toon4s/spark/SparkJsonInterop.scala
@@ -217,12 +217,12 @@ object SparkJsonInterop {
    *   {{{
    * val json = JObj(VectorMap("name" -> JString("Alice"), "age" -> JNumber(25)))
    * val value = jsonValueToValue(json)
-   * // value: Map("name" -> "Alice", "age" -> 25.0)
+   * // value: Map("name" -> "Alice", "age" -> 25)
    *   }}}
    */
   def jsonValueToValue(json: JsonValue): Any = json match {
   case JString(s)     => s
-  case JNumber(n)     => n.toDouble // Spark uses Double for numeric types
+  case JNumber(n)     => numberToScala(n)
   case JBool(b)       => b
   case JNull          => null
   case JArray(values) =>
@@ -230,6 +230,18 @@ object SparkJsonInterop {
   case JObj(fields) =>
     fields.map { case (k, v) => k -> jsonValueToValue(v) }.toMap
   }
+
+  /**
+   * Convert a numeric JsonValue to the most faithful Scala value. Integral numbers that fit in a
+   * Long stay Long (so integers past 2^53 do not round), larger integers stay BigDecimal, and only
+   * genuinely fractional numbers become Double.
+   */
+  private def numberToScala(n: BigDecimal): Any =
+    if (n.isWhole) {
+      if (n.isValidLong) n.toLong else n
+    } else {
+      n.toDouble
+    }
 
   /**
    * Convert JsonValue to Spark Row with schema validation.
@@ -350,7 +362,7 @@ object SparkJsonInterop {
 
     // ========== Fallback ==========
     case (JString(s), _) => s
-    case (JNumber(n), _) => n.toDouble
+    case (JNumber(n), _) => numberToScala(n)
     case (JBool(b), _)   => b
     case _               => null
     }

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkJsonInteropTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkJsonInteropTest.scala
@@ -267,4 +267,14 @@ class SparkJsonInteropTest extends SparkTestSuite {
     assertEquals(scores.get(2), Some("high"))
   }
 
+  test("jsonValueToValue: keep large integers as Long, not rounded Double") {
+    val big = JNumber(BigDecimal(Long.MaxValue))
+    assertEquals(SparkJsonInterop.jsonValueToValue(big), Long.MaxValue)
+  }
+
+  test("jsonValueToValue: keep fractional numbers as Double") {
+    val frac = JNumber(BigDecimal("25.5"))
+    assertEquals(SparkJsonInterop.jsonValueToValue(frac), 25.5D)
+  }
+
 }

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkToonOpsTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkToonOpsTest.scala
@@ -513,6 +513,26 @@ class SparkToonOpsTest extends SparkTestSuite {
     }
   }
 
+  test("round trip: preserve 64 bit integers past 2^53 exactly") {
+    val schema = StructType(Seq(
+      StructField("id", LongType),
+      StructField("name", StringType),
+    ))
+
+    val big = Long.MaxValue
+    val data = Seq(Row(big, "edge"))
+    val originalDf = spark.createDataFrame(data.asJava, schema)
+
+    val toonResult = originalDf.toToon(key = "data")
+    assert(toonResult.isRight)
+
+    toonResult.foreach { toonChunks =>
+      val decodedResult = SparkToonOps.fromToon(toonChunks, schema)(spark)
+      assert(decodedResult.isRight)
+      decodedResult.foreach(decodedDf => assertEquals(decodedDf.collect().head.getLong(0), big))
+    }
+  }
+
   test("fromToonDataset: decode distributed TOON dataset to DataFrame") {
     val schema = StructType(Seq(
       StructField("id", IntegerType),

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkToonOpsTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/SparkToonOpsTest.scala
@@ -529,7 +529,7 @@ class SparkToonOpsTest extends SparkTestSuite {
     toonResult.foreach { toonChunks =>
       val decodedResult = SparkToonOps.fromToon(toonChunks, schema)(spark)
       assert(decodedResult.isRight)
-      decodedResult.foreach(decodedDf => assertEquals(decodedDf.collect().head.getLong(0), big))
+      decodedResult.foreach(decodedDf => assertEquals(decodedDf.take(1000).head.getLong(0), big))
     }
   }
 


### PR DESCRIPTION
jsonValueToValue returned Double for every number, rounding integers past 2^53. It now returns Long when the value is integral and fits. Adds a Long.MaxValue round trip test through toToon and fromToon. Production decode path was already lossless and stays unchanged.