### PR TITLE
Add raw value primitive formatters in core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
+import com.typesafe.tools.mima.core._
 import sbt._
 import sbt.Keys._
 import sbtdynver.DynVerPlugin.autoImport._
-import com.typesafe.tools.mima.core._
 
 lazy val Scala3Latest = "3.3.3"
 
@@ -119,9 +119,15 @@ lazy val core = (project in file("core"))
     // Internal parsing methods gained an isStrict parameter in v3.3 conformance work.
     // These are implementation utilities, not part of the documented public API.
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"
+      ),
     ),
   )
 
@@ -169,11 +175,11 @@ lazy val sparkIntegration = (project in file("spark-integration"))
     // Override scalaVersion to Scala 2.13 (Spark doesn't support Scala 3)
     scalaVersion := Scala213Latest,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % SparkSqlVersion % Provided,
-      ("org.llm4s"       %% "core"      % Llm4sVersion % Provided).intransitive(),
-      "org.scalameta"    %% "munit"     % "1.2.1" % Test,
-      "org.scalacheck"   %% "scalacheck"       % "1.19.0" % Test,
-      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"  % Test,
+      "org.apache.spark" %% "spark-sql"        % SparkSqlVersion % Provided,
+      ("org.llm4s"       %% "core"             % Llm4sVersion    % Provided).intransitive(),
+      "org.scalameta"    %% "munit"            % "1.2.1"         % Test,
+      "org.scalacheck"   %% "scalacheck"       % "1.19.0"        % Test,
+      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"         % Test,
     ),
     scalacOptions ++= commonScalacOptions,
     // Allow Scala 2.13 compiler to read Scala 3 TASTy from toon4s-core
@@ -198,7 +204,7 @@ lazy val sparkIntegration = (project in file("spark-integration"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
     ),
     // ScalaDoc configuration
     Compile / doc / scalacOptions ++= Seq(

--- a/core/src/main/scala/io/toonformat/toon4s/encode/Primitives.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Primitives.scala
@@ -55,6 +55,26 @@ private[toon4s] object Primitives {
     if (normalized == "-0") "0" else normalized
   }
 
+  // Raw-value primitive formatting. Lets typed callers (such as the Spark integration) emit
+  // canonical TOON tokens straight from primitive values without first wrapping them in a
+  // JsonValue. Output is identical to encodePrimitive for the same value.
+  //
+  // Integral, boolean, null and string values are formatted without allocating a BigDecimal.
+  // Double values still go through BigDecimal because matching the canonical plain-decimal form
+  // (no exponent) requires decimal expansion that Double.toString does not provide.
+
+  val nullToken: String = C.NullLiteral
+
+  def formatBoolean(b: Boolean): String = if (b) C.TrueLiteral else C.FalseLiteral
+
+  def formatLong(n: Long): String = java.lang.Long.toString(n)
+
+  def formatBigInt(n: BigInt): String = n.toString
+
+  def formatDouble(d: Double): String = normalizeNumber(BigDecimal(d))
+
+  def formatBigDecimal(n: BigDecimal): String = normalizeNumber(n)
+
   def encodeKey(key: String): String = {
     if (isValidUnquotedKey(key)) key else quoteAndEscape(key)
   }

--- a/core/src/test/scala/io/toonformat/toon4s/encode/RawPrimitiveFormatSpec.scala
+++ b/core/src/test/scala/io/toonformat/toon4s/encode/RawPrimitiveFormatSpec.scala
@@ -13,16 +13,12 @@ class RawPrimitiveFormatSpec extends FunSuite {
   private val delimiters = List(Delimiter.Comma, Delimiter.Tab, Delimiter.Pipe)
 
   private def assertParity(formatted: String, json: JsonValue): Unit =
-    delimiters.foreach { d =>
-      assertEquals(formatted, Primitives.encodePrimitive(json, d))
-    }
+    delimiters.foreach(d => assertEquals(formatted, Primitives.encodePrimitive(json, d)))
 
   test("formatLong matches encodePrimitive") {
     val values =
       List(0L, 1L, -5L, 100L, 1000000000000L, Long.MaxValue, Long.MinValue)
-    values.foreach { n =>
-      assertParity(Primitives.formatLong(n), JNumber(BigDecimal(n)))
-    }
+    values.foreach(n => assertParity(Primitives.formatLong(n), JNumber(BigDecimal(n))))
   }
 
   test("formatBigInt matches encodePrimitive for values beyond Long") {
@@ -31,23 +27,17 @@ class RawPrimitiveFormatSpec extends FunSuite {
       BigInt("-9223372036854775809"),
       BigInt("100000000000000000000000"),
     )
-    values.foreach { n =>
-      assertParity(Primitives.formatBigInt(n), JNumber(BigDecimal(n)))
-    }
+    values.foreach(n => assertParity(Primitives.formatBigInt(n), JNumber(BigDecimal(n))))
   }
 
   test("formatDouble matches encodePrimitive") {
-    val values = List(0.0d, -0.0d, 3.14d, 25.5d, 1e10d, 1e-3d, 123.456d)
-    values.foreach { d =>
-      assertParity(Primitives.formatDouble(d), JNumber(BigDecimal(d)))
-    }
+    val values = List(0.0D, -0.0D, 3.14D, 25.5D, 1e10D, 1e-3D, 123.456D)
+    values.foreach(d => assertParity(Primitives.formatDouble(d), JNumber(BigDecimal(d))))
   }
 
   test("formatBigDecimal matches encodePrimitive") {
     val values = List(BigDecimal("1.5000"), BigDecimal("1e6"), BigDecimal("-0"))
-    values.foreach { n =>
-      assertParity(Primitives.formatBigDecimal(n), JNumber(n))
-    }
+    values.foreach(n => assertParity(Primitives.formatBigDecimal(n), JNumber(n)))
   }
 
   test("formatBoolean and nullToken match encodePrimitive") {
@@ -55,4 +45,5 @@ class RawPrimitiveFormatSpec extends FunSuite {
     assertParity(Primitives.formatBoolean(false), JBool(false))
     assertParity(Primitives.nullToken, JNull)
   }
+
 }

--- a/core/src/test/scala/io/toonformat/toon4s/encode/RawPrimitiveFormatSpec.scala
+++ b/core/src/test/scala/io/toonformat/toon4s/encode/RawPrimitiveFormatSpec.scala
@@ -1,0 +1,58 @@
+package io.toonformat.toon4s
+package encode
+
+import io.toonformat.toon4s.JsonValue._
+import munit.FunSuite
+
+/**
+ * The raw-value formatters must produce output identical to encodePrimitive for the same value.
+ * This locks the parity that the Spark direct emitter relies on.
+ */
+class RawPrimitiveFormatSpec extends FunSuite {
+
+  private val delimiters = List(Delimiter.Comma, Delimiter.Tab, Delimiter.Pipe)
+
+  private def assertParity(formatted: String, json: JsonValue): Unit =
+    delimiters.foreach { d =>
+      assertEquals(formatted, Primitives.encodePrimitive(json, d))
+    }
+
+  test("formatLong matches encodePrimitive") {
+    val values =
+      List(0L, 1L, -5L, 100L, 1000000000000L, Long.MaxValue, Long.MinValue)
+    values.foreach { n =>
+      assertParity(Primitives.formatLong(n), JNumber(BigDecimal(n)))
+    }
+  }
+
+  test("formatBigInt matches encodePrimitive for values beyond Long") {
+    val values = List(
+      BigInt("9223372036854775808"),
+      BigInt("-9223372036854775809"),
+      BigInt("100000000000000000000000"),
+    )
+    values.foreach { n =>
+      assertParity(Primitives.formatBigInt(n), JNumber(BigDecimal(n)))
+    }
+  }
+
+  test("formatDouble matches encodePrimitive") {
+    val values = List(0.0d, -0.0d, 3.14d, 25.5d, 1e10d, 1e-3d, 123.456d)
+    values.foreach { d =>
+      assertParity(Primitives.formatDouble(d), JNumber(BigDecimal(d)))
+    }
+  }
+
+  test("formatBigDecimal matches encodePrimitive") {
+    val values = List(BigDecimal("1.5000"), BigDecimal("1e6"), BigDecimal("-0"))
+    values.foreach { n =>
+      assertParity(Primitives.formatBigDecimal(n), JNumber(n))
+    }
+  }
+
+  test("formatBoolean and nullToken match encodePrimitive") {
+    assertParity(Primitives.formatBoolean(true), JBool(true))
+    assertParity(Primitives.formatBoolean(false), JBool(false))
+    assertParity(Primitives.nullToken, JNull)
+  }
+}


### PR DESCRIPTION
Adds formatters that turn primitive values into canonical TOON tokens without a JsonValue wrapper. Integral, boolean, null and string paths allocate no BigDecimal. Parity tests lock the output equal to encodePrimitive across all delimiters. Foundation for a faster Spark emitter.