### PR TITLE
Deprecate legacy LLM client surface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
+import com.typesafe.tools.mima.core._
 import sbt._
 import sbt.Keys._
 import sbtdynver.DynVerPlugin.autoImport._
-import com.typesafe.tools.mima.core._
 
 lazy val Scala3Latest = "3.3.3"
 
@@ -119,9 +119,15 @@ lazy val core = (project in file("core"))
     // Internal parsing methods gained an isStrict parameter in v3.3 conformance work.
     // These are implementation utilities, not part of the documented public API.
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"
+      ),
     ),
   )
 
@@ -169,11 +175,11 @@ lazy val sparkIntegration = (project in file("spark-integration"))
     // Override scalaVersion to Scala 2.13 (Spark doesn't support Scala 3)
     scalaVersion := Scala213Latest,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % SparkSqlVersion % Provided,
-      ("org.llm4s"       %% "core"      % Llm4sVersion % Provided).intransitive(),
-      "org.scalameta"    %% "munit"     % "1.2.1" % Test,
-      "org.scalacheck"   %% "scalacheck"       % "1.19.0" % Test,
-      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"  % Test,
+      "org.apache.spark" %% "spark-sql"        % SparkSqlVersion % Provided,
+      ("org.llm4s"       %% "core"             % Llm4sVersion    % Provided).intransitive(),
+      "org.scalameta"    %% "munit"            % "1.2.1"         % Test,
+      "org.scalacheck"   %% "scalacheck"       % "1.19.0"        % Test,
+      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"         % Test,
     ),
     scalacOptions ++= commonScalacOptions,
     // Allow Scala 2.13 compiler to read Scala 3 TASTy from toon4s-core
@@ -198,7 +204,7 @@ lazy val sparkIntegration = (project in file("spark-integration"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
     ),
     // ScalaDoc configuration
     Compile / doc / scalacOptions ++= Seq(

--- a/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/LlmClient.scala
+++ b/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/LlmClient.scala
@@ -6,6 +6,10 @@ package io.toonformat.toon4s.spark.llm
  * This type is kept for migration tests only. New production paths should use
  * `writeToLlmPartitions` with llm4s clients through `LlmPartitionWriterFactory`.
  */
+@deprecated(
+  "Legacy client. Use LlmPartitionWriterFactory.fromClientFactory with an llm4s client. Scheduled for removal.",
+  "0.9.0",
+)
 trait LlmClient {
 
   // ========== Core llm4s-Compatible Methods ==========

--- a/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/LlmPartitionSink.scala
+++ b/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/LlmPartitionSink.scala
@@ -3,6 +3,7 @@ package io.toonformat.toon4s.spark.llm
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 import org.llm4s.error.{LLMError, UnknownError}
@@ -114,6 +115,11 @@ object LlmPartitionWriterFactory {
       }
     }
 
+  @deprecated(
+    "Legacy client path. Use fromClientFactory with an llm4s client. Scheduled for removal.",
+    "0.9.0",
+  )
+  @nowarn("cat=deprecation")
   def fromLegacyClientFactory(
       clientFactory: () => LlmClient,
       idempotencyStore: IdempotencyStore = IdempotencyStore.Noop,

--- a/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/MockLlmClient.scala
+++ b/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/MockLlmClient.scala
@@ -1,6 +1,10 @@
 package io.toonformat.toon4s.spark.llm
 
+import scala.annotation.nowarn
+
 /** Mock implementation for compatibility tests. */
+@deprecated("Legacy mock for LlmClient. Scheduled for removal.", "0.9.0")
+@nowarn("cat=deprecation")
 class MockLlmClient(
     val config: LlmConfig,
     responses: Map[String, String] = Map.empty,
@@ -65,6 +69,8 @@ class MockLlmClient(
 
 }
 
+@deprecated("Legacy mock for LlmClient. Scheduled for removal.", "0.9.0")
+@nowarn("cat=deprecation")
 object MockLlmClient {
 
   /** Create mock client with default config. */

--- a/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/ToonLlmResponseValidator.scala
+++ b/spark-integration/src/main/scala/io/toonformat/toon4s/spark/llm/ToonLlmResponseValidator.scala
@@ -6,6 +6,7 @@ package io.toonformat.toon4s.spark.llm
  * This detects common signs that a model did not understand the TOON payload format and returned a
  * clarification request or raw JSON echo instead of the requested task output.
  */
+@deprecated("Legacy LLM response helper. Scheduled for removal.", "0.9.0")
 object ToonLlmResponseValidator {
 
   sealed trait ValidationIssue extends Product with Serializable {

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/llm/LlmClientTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/llm/LlmClientTest.scala
@@ -1,7 +1,10 @@
 package io.toonformat.toon4s.spark.llm
 
+import scala.annotation.nowarn
+
 import munit.FunSuite
 
+@nowarn("cat=deprecation")
 class LlmClientTest extends FunSuite {
 
   test("Message: create system message") {

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/llm/ToonLlmResponseValidatorTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/llm/ToonLlmResponseValidatorTest.scala
@@ -1,7 +1,10 @@
 package io.toonformat.toon4s.spark.llm
 
+import scala.annotation.nowarn
+
 import munit.FunSuite
 
+@nowarn("cat=deprecation")
 class ToonLlmResponseValidatorTest extends FunSuite {
 
   test("validate: accepts normal response") {


### PR DESCRIPTION
Marks the legacy LlmClient, MockLlmClient, ToonLlmResponseValidator and the fromLegacyClientFactory overload as deprecated, with a since 0.9.0 note. Internal and test use sites are annotated so the build stays clean under fatal warnings. Nothing is removed yet, so binary compatibility holds. Full surgical removal will follow in a later release.