### PR TITLE
Add ai_query composition recipe and test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
+import com.typesafe.tools.mima.core._
 import sbt._
 import sbt.Keys._
 import sbtdynver.DynVerPlugin.autoImport._
-import com.typesafe.tools.mima.core._
 
 lazy val Scala3Latest = "3.3.3"
 
@@ -119,9 +119,15 @@ lazy val core = (project in file("core"))
     // Internal parsing methods gained an isStrict parameter in v3.3 conformance work.
     // These are implementation utilities, not part of the documented public API.
     mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.Parser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseArrayHeaderLine"
+      ),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "io.toonformat.toon4s.decode.parsers.ArrayHeaderParser.parseBracketSegment"
+      ),
     ),
   )
 
@@ -169,11 +175,11 @@ lazy val sparkIntegration = (project in file("spark-integration"))
     // Override scalaVersion to Scala 2.13 (Spark doesn't support Scala 3)
     scalaVersion := Scala213Latest,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-sql" % SparkSqlVersion % Provided,
-      ("org.llm4s"       %% "core"      % Llm4sVersion % Provided).intransitive(),
-      "org.scalameta"    %% "munit"     % "1.2.1" % Test,
-      "org.scalacheck"   %% "scalacheck"       % "1.19.0" % Test,
-      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"  % Test,
+      "org.apache.spark" %% "spark-sql"        % SparkSqlVersion % Provided,
+      ("org.llm4s"       %% "core"             % Llm4sVersion    % Provided).intransitive(),
+      "org.scalameta"    %% "munit"            % "1.2.1"         % Test,
+      "org.scalacheck"   %% "scalacheck"       % "1.19.0"        % Test,
+      "org.scalameta"    %% "munit-scalacheck" % "1.2.0"         % Test,
     ),
     scalacOptions ++= commonScalacOptions,
     // Allow Scala 2.13 compiler to read Scala 3 TASTy from toon4s-core
@@ -198,7 +204,7 @@ lazy val sparkIntegration = (project in file("spark-integration"))
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
     ),
     // ScalaDoc configuration
     Compile / doc / scalacOptions ++= Seq(

--- a/spark-integration/examples/README.md
+++ b/spark-integration/examples/README.md
@@ -31,6 +31,49 @@ All examples are based on [TOON Generation Benchmark](https://github.com/veterta
 - ❌ **TOON fails**: Deep hierarchies (0% one-shot accuracy)
 - ⚠️ **Prompt tax**: TOON overhead > savings for small datasets (< 1KB)
 
+## Compose with Databricks AI Functions (ai_query)
+
+toon4s does not replace platform LLM functions like Databricks `ai_query`. It composes with them:
+toon4s encodes each chunk to compact TOON (about 40% fewer tokens than JSON for tabular data),
+and `ai_query` runs the model over those chunks. Fewer tokens per call means lower cost and more
+rows per request.
+
+The encoding step uses the real encoder (`toToonDataset`), not the row-text UDFs, so the payload
+is canonical TOON.
+
+```scala
+import io.toonformat.toon4s.spark.SparkToonOps._
+
+// 1. Encode to compact TOON chunks (one string per chunk).
+val chunks = df.toToonDataset(ToonSparkOptions(key = "rows", maxRowsPerChunk = 500))
+chunks.createOrReplaceTempView("toon_chunks")
+
+// 2. Run the model over the chunks. On Databricks ai_query is built in.
+spark.sql("""
+  SELECT ai_query('my-serving-endpoint', value) AS analysis
+  FROM toon_chunks
+""")
+```
+
+Pure SQL on Databricks, once the chunks are a table or view:
+
+```sql
+SELECT ai_query('my-serving-endpoint', value) AS analysis
+FROM toon_chunks;
+```
+
+To run the recipe locally or in CI, register a stand-in for `ai_query` before the query:
+
+```scala
+spark.udf.register(
+  "ai_query",
+  (endpoint: String, prompt: String) => s"$endpoint analyzed ${prompt.length} chars",
+)
+```
+
+A runnable, verified version of this recipe lives in
+`src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala`.
+
 ## Running Examples
 
 ### 1. Try in 5 minutes

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
@@ -32,12 +32,12 @@ class AiQueryRecipeTest extends SparkTestSuite {
     val chunks = df.toToonDataset(ToonSparkOptions(key = "rows", maxRowsPerChunk = 5))
 
     // Real TOON, not JSON: the tabular header is present.
-    assert(chunks.collect().forall(_.contains("rows[")))
+    assert(chunks.take(1000).forall(_.contains("rows[")))
 
     chunks.createOrReplaceTempView("toon_chunks")
     val responses = spark
       .sql("SELECT ai_query('my-endpoint', value) AS analysis FROM toon_chunks")
-      .collect()
+      .take(1000)
       .map(_.getString(0))
 
     assertEquals(responses.length, 2)

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
@@ -1,0 +1,46 @@
+package io.toonformat.toon4s.spark
+
+import scala.jdk.CollectionConverters._
+
+import io.toonformat.toon4s.spark.SparkToonOps._
+import io.toonformat.toon4s.spark.testkit.SparkTestSuite
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+/**
+ * Reference recipe: compose toon4s with a model-calling SQL function such as Databricks ai_query.
+ * toon4s encodes each chunk to compact TOON, then ai_query runs over those chunks. On Databricks
+ * ai_query is built in; here it is mocked so the recipe runs locally and in CI.
+ */
+class AiQueryRecipeTest extends SparkTestSuite {
+
+  test("toon4s chunks feed a mocked ai_query SQL call") {
+    // Stand in for the Databricks ai_query(endpoint, prompt) built in.
+    spark.udf.register(
+      "ai_query",
+      (endpoint: String, prompt: String) => s"$endpoint analyzed ${prompt.length} chars",
+    )
+
+    val schema = StructType(Seq(
+      StructField("id", LongType),
+      StructField("name", StringType),
+      StructField("score", DoubleType),
+    ))
+    val data = (1 to 10).map(i => Row(i.toLong, s"user$i", i.toDouble))
+    val df = spark.createDataFrame(data.asJava, schema)
+
+    val chunks = df.toToonDataset(ToonSparkOptions(key = "rows", maxRowsPerChunk = 5))
+
+    // Real TOON, not JSON: the tabular header is present.
+    assert(chunks.collect().forall(_.contains("rows[")))
+
+    chunks.createOrReplaceTempView("toon_chunks")
+    val responses = spark
+      .sql("SELECT ai_query('my-endpoint', value) AS analysis FROM toon_chunks")
+      .collect()
+      .map(_.getString(0))
+
+    assertEquals(responses.length, 2)
+    assert(responses.forall(_.startsWith("my-endpoint analyzed")))
+  }
+}

--- a/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
+++ b/spark-integration/src/test/scala/io/toonformat/toon4s/spark/AiQueryRecipeTest.scala
@@ -43,4 +43,5 @@ class AiQueryRecipeTest extends SparkTestSuite {
     assertEquals(responses.length, 2)
     assert(responses.forall(_.startsWith("my-endpoint analyzed")))
   }
+
 }


### PR DESCRIPTION
Shows the honest composition: toon4s encodes compact TOON chunks with toToonDataset, then a model function like Databricks ai_query runs over them. Adds a runnable test with a mock ai_query and a recipe section in the examples README. Reinforces compose not compete.