### PR TITLE
Reduce allocation in tabular detection

### DIFF
--- a/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
@@ -251,10 +251,13 @@ object Encoders {
       val keys = first.keys.toList
       if (keys.isEmpty) None
       else {
-        val firstKeySet = first.keySet
-        // Use iterator for early exit on non-uniform rows
+        val firstSize = first.size
+        // A row is uniform with the first when it has the same key set and only primitive values.
+        // Compare keys by size plus containment so no per-row keySet is allocated.
         val uniform = rows.iterator.forall { row =>
-          row.keySet == firstKeySet && row.valuesIterator.forall(isPrimitive)
+          row.size == firstSize &&
+          keys.forall(row.contains) &&
+          row.valuesIterator.forall(isPrimitive)
         }
         if (uniform) Some(keys) else None
       }


### PR DESCRIPTION
Tabular detection compared key sets by allocating a set per row. It now checks size and key containment with no per row set allocation. Behavior is identical. This cuts allocation under wide or large inputs but did not change throughput on the current benchmark.