### PR TITLE
Document numeric domain and pin plain number form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,14 @@ These are conscious design decisions:
 - **Deterministic ordering**: We use `VectorMap` instead of `HashMap` because **predictable field ordering** matters
   more than raw lookup speed. This aids debugging, testing, and spec compliance.
 
+- **Numeric domain (spec sections 2 and 4)**: The core models numbers as arbitrary-precision `BigDecimal`, so decoding
+  is lossless (the spec's recommended lossless-first policy) and no value is rounded through binary floating point.
+  Numbers are emitted in plain decimal across the entire finite range, including `|n| >= 1e21` and `|n| < 1e-6` where the
+  spec permits, but does not require, exponent notation. This is conformant and deterministic; it differs in form, not
+  value, from JavaScript-based encoders which use exponent outside that range. `NaN` and `+/-Infinity` normalize to
+  `null` (spec section 3). In the Spark integration the schema-aware decode path is lossless and large integers
+  round-trip exactly.
+
 - **No mutation**: Immutability with tailrec. Trade: ~20% throughput decrease. Gain: **zero race conditions, zero hidden
   state, composable functions**.
 

--- a/core/src/main/scala/io/toonformat/toon4s/encode/Primitives.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Primitives.scala
@@ -50,6 +50,9 @@ private[toon4s] object Primitives {
     builder.result()
   }
 
+  // toPlainString emits plain decimal across the whole finite range. Spec section 2 requires plain
+  // form only for 1e-6 <= |n| < 1e21 and merely permits exponent outside it, so emitting plain
+  // everywhere is conformant and deterministic (it differs in form, not value, from JS encoders).
   private def normalizeNumber(n: BigDecimal): String = {
     val bd = n.bigDecimal
     // Fast path: integral value (no fractional digits) that fits in a long. The canonical form of

--- a/core/src/test/scala/io/toonformat/toon4s/CanonicalNumberSpec.scala
+++ b/core/src/test/scala/io/toonformat/toon4s/CanonicalNumberSpec.scala
@@ -315,4 +315,39 @@ class CanonicalNumberSpec extends FunSuite {
     }
   }
 
+  // Spec section 2 mandates plain form only for 1e-6 <= |n| < 1e21 and permits (but does not
+  // require) exponent notation outside that range. toon4s deliberately emits plain decimal across
+  // the whole finite range. This is conformant but an intentional choice: it differs in form (not
+  // value) from JS-based encoders, which use exponent outside the same range. These tests pin that
+  // choice so a regression toward exponent notation is caught.
+  test("numbers at or above 1e21 stay plain decimal, not exponent") {
+    val testCases = List(
+      BigDecimal("1e21") -> "1000000000000000000000",
+      BigDecimal("1e22") -> "10000000000000000000000",
+      BigDecimal("1.5e22") -> "15000000000000000000000",
+      BigDecimal("-1e21") -> "-1000000000000000000000",
+    )
+    testCases.foreach {
+      case (input, expected) =>
+        val encoded = Toon.encode(JObj(VectorMap("num" -> JNumber(input)))).getOrElse("")
+        assert(encoded.contains(expected), s"expected '$expected' in:\n$encoded")
+        assert(!encoded.contains('e') && !encoded.contains('E'), s"no exponent allowed:\n$encoded")
+    }
+  }
+
+  test("numbers below 1e-6 stay plain decimal, not exponent") {
+    val testCases = List(
+      BigDecimal("1e-7") -> "0.0000001",
+      BigDecimal("1e-8") -> "0.00000001",
+      BigDecimal("5e-7") -> "0.0000005",
+      BigDecimal("-1e-7") -> "-0.0000001",
+    )
+    testCases.foreach {
+      case (input, expected) =>
+        val encoded = Toon.encode(JObj(VectorMap("num" -> JNumber(input)))).getOrElse("")
+        assert(encoded.contains(expected), s"expected '$expected' in:\n$encoded")
+        assert(!encoded.contains('e') && !encoded.contains('E'), s"no exponent allowed:\n$encoded")
+    }
+  }
+
 }


### PR DESCRIPTION
Adds tests that lock the plain decimal form for numbers outside the 1e-6 to 1e21 range, where the spec permits but does not require exponent notation, so a regression toward exponent form is caught. Documents the numeric domain in the README as the spec requires: arbitrary precision and lossless, plain decimal across the whole range, NaN and infinity to null. No behavior change.