### PR TITLE
Fix scaladoc link that broke the release

### DIFF
--- a/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
+++ b/core/src/main/scala/io/toonformat/toon4s/encode/Encoders.scala
@@ -60,7 +60,7 @@ object Encoders {
 
   /**
    * Encode a uniform tabular array under `key` from pre-formatted row tokens. Each token must
-   * already be a canonical TOON primitive (see [[Primitives]] format methods). The output is
+   * already be a canonical TOON primitive (see the Primitives format methods). The output is
    * byte-identical to encoding `JObj(key -> JArray(rows))` where every row is a flat JObj of the
    * same `fields`.
    *


### PR DESCRIPTION
A public doc comment linked to the private Primitives object with wiki link syntax. Scala 3 scaladoc tolerates it but Scala 2.13 scaladoc fails hard, which broke doc generation during release. Replaced the link with plain text. Both Scala versions now generate docs cleanly. No code change.